### PR TITLE
nomad agent does not have a -pid-file option

### DIFF
--- a/templates/nomad.upstart.erb
+++ b/templates/nomad.upstart.erb
@@ -25,7 +25,7 @@ script
     [ -e $DEFAULTS ] && . $DEFAULTS
 
     export GOMAXPROCS=${GOMAXPROCS:-2}
-    exec start-stop-daemon -c $USER -g $GROUP -p $PID_FILE -x $NOMAD -S -- agent -config $CONFIG -pid-file $PID_FILE <%= scope.lookupvar('nomad::extra_options') %>
+    exec start-stop-daemon -c $USER -g $GROUP -p $PID_FILE -x $NOMAD -S -- agent -config $CONFIG <%= scope.lookupvar('nomad::extra_options') %>
 end script
 
 pre-stop script


### PR DESCRIPTION
this bug basically produces a startup error on nomads side because there is no such parameter :)