### PR TITLE
correct var file setting for systemd

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -34,7 +34,7 @@ class nomad::config(
         }
       }
       'systemd' : {
-        file { '/etc/sysconfig/nomad':
+        file { '/etc/sysconfig':
           ensure => directory,
           mode   => '0644',
           owner  => 'root',


### PR DESCRIPTION
In order to use this module with systemd we need to have the /etc/syslog/nomad file that contains the environment variables loaded by systemd. Previously this filesystem location was set as directory. 