### PR TITLE
Nomad has arm builds, adding it to the $arch case

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,7 @@ class nomad::params {
   case $::architecture {
     'x86_64', 'amd64': { $arch = 'amd64' }
     'i386':            { $arch = '386'   }
+    'armv7l':          { $arch = 'arm'   }
     default:           {
       fail("Unsupported kernel architecture: ${::architecture}")
     }


### PR DESCRIPTION
When installing on arm single board computers (for example, Raspberry PIs) an extra case needs to be added to be able to download the arm binaries for Nomad. This was tested on Raspberry Pis, but potentially there are other arm architectures that can use the same binary.